### PR TITLE
Initial stats API (Go) and frontend ranking integration

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"app-family/backend/internal/api"
+)
+
+func main() {
+	srv := api.NewServer()
+	addr := ":8080"
+	log.Printf("API listening on %s", addr)
+	if err := http.ListenAndServe(addr, srv.Routes()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,3 @@
+module app-family/backend
+
+go 1.22

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -1,0 +1,197 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+)
+
+type Member struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Role string `json:"role"`
+}
+
+type Task struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	Category  string `json:"category"`
+	OwnerID   string `json:"ownerId"`
+	Frequency string `json:"frequency"`
+	Completed bool   `json:"completed"`
+}
+
+type Server struct {
+	members []Member
+	tasks   []Task
+}
+
+type UserStat struct {
+	MemberID       string `json:"memberId"`
+	Name           string `json:"name"`
+	Role           string `json:"role"`
+	TotalTasks     int    `json:"totalTasks"`
+	CompletedTasks int    `json:"completedTasks"`
+	CompletionRate int    `json:"completionRate"`
+}
+
+type CategoryStat struct {
+	Category       string `json:"category"`
+	TotalTasks     int    `json:"totalTasks"`
+	CompletedTasks int    `json:"completedTasks"`
+	CompletionRate int    `json:"completionRate"`
+}
+
+type Summary struct {
+	TotalTasks     int `json:"totalTasks"`
+	CompletedTasks int `json:"completedTasks"`
+	CompletionRate int `json:"completionRate"`
+}
+
+type StatsResponse struct {
+	Summary    Summary        `json:"summary"`
+	ByUser     []UserStat     `json:"byUser"`
+	ByCategory []CategoryStat `json:"byCategory"`
+}
+
+func NewServer() *Server {
+	return &Server{
+		members: []Member{
+			{ID: "m1", Name: "Ana", Role: "Responsável"},
+			{ID: "m2", Name: "Pedro", Role: "Responsável"},
+			{ID: "m3", Name: "Lia", Role: "Filho(a)"},
+		},
+		tasks: []Task{
+			{ID: "t1", Title: "Organizar brinquedos", Category: "Organização", OwnerID: "m3", Frequency: "Diária", Completed: true},
+			{ID: "t2", Title: "Preparar o jantar", Category: "Cozinha", OwnerID: "m2", Frequency: "Diária", Completed: false},
+			{ID: "t3", Title: "Limpar banheiro", Category: "Limpeza", OwnerID: "m1", Frequency: "Semanal", Completed: false},
+			{ID: "t4", Title: "Arrumar camas", Category: "Organização", OwnerID: "m3", Frequency: "Diária", Completed: true},
+		},
+	}
+}
+
+func (s *Server) Routes() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/health", s.handleHealth)
+	mux.HandleFunc("/api/members", s.handleMembers)
+	mux.HandleFunc("/api/tasks", s.handleTasks)
+	mux.HandleFunc("/api/stats", s.handleStats)
+	mux.HandleFunc("/api/stats/ranking", s.handleRanking)
+	return withCORS(mux)
+}
+
+func withCORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleMembers(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, s.members)
+}
+
+func (s *Server) handleTasks(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, s.tasks)
+}
+
+func (s *Server) buildStats() StatsResponse {
+	totalTasks := len(s.tasks)
+	completed := 0
+	byCategoryMap := map[string]*CategoryStat{}
+	byUser := make([]UserStat, 0, len(s.members))
+
+	for _, member := range s.members {
+		userTasks := 0
+		userCompleted := 0
+		for _, task := range s.tasks {
+			if task.OwnerID != member.ID {
+				continue
+			}
+			userTasks++
+			if task.Completed {
+				userCompleted++
+			}
+		}
+		rate := 0
+		if userTasks > 0 {
+			rate = userCompleted * 100 / userTasks
+		}
+		byUser = append(byUser, UserStat{
+			MemberID:       member.ID,
+			Name:           member.Name,
+			Role:           member.Role,
+			TotalTasks:     userTasks,
+			CompletedTasks: userCompleted,
+			CompletionRate: rate,
+		})
+	}
+
+	for _, task := range s.tasks {
+		if task.Completed {
+			completed++
+		}
+		if _, ok := byCategoryMap[task.Category]; !ok {
+			byCategoryMap[task.Category] = &CategoryStat{Category: task.Category}
+		}
+		entry := byCategoryMap[task.Category]
+		entry.TotalTasks++
+		if task.Completed {
+			entry.CompletedTasks++
+		}
+	}
+
+	byCategory := make([]CategoryStat, 0, len(byCategoryMap))
+	for _, stat := range byCategoryMap {
+		if stat.TotalTasks > 0 {
+			stat.CompletionRate = stat.CompletedTasks * 100 / stat.TotalTasks
+		}
+		byCategory = append(byCategory, *stat)
+	}
+	sort.Slice(byCategory, func(i, j int) bool {
+		return byCategory[i].Category < byCategory[j].Category
+	})
+
+	overallRate := 0
+	if totalTasks > 0 {
+		overallRate = completed * 100 / totalTasks
+	}
+	return StatsResponse{
+		Summary:    Summary{TotalTasks: totalTasks, CompletedTasks: completed, CompletionRate: overallRate},
+		ByUser:     byUser,
+		ByCategory: byCategory,
+	}
+}
+
+func (s *Server) handleStats(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, s.buildStats())
+}
+
+func (s *Server) handleRanking(w http.ResponseWriter, _ *http.Request) {
+	stats := s.buildStats()
+	ranking := make([]UserStat, len(stats.ByUser))
+	copy(ranking, stats.ByUser)
+	sort.Slice(ranking, func(i, j int) bool {
+		if ranking[i].CompletedTasks == ranking[j].CompletedTasks {
+			return ranking[i].CompletionRate > ranking[j].CompletionRate
+		}
+		return ranking[i].CompletedTasks > ranking[j].CompletedTasks
+	})
+	writeJSON(w, http.StatusOK, ranking)
+}

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,316 @@
+const apiBase = "http://127.0.0.1:8080";
+
+const defaultMembers = [
+  { id: "m1", name: "Ana", role: "Responsável" },
+  { id: "m2", name: "Pedro", role: "Responsável" },
+  { id: "m3", name: "Lia", role: "Filho(a)" },
+];
+
+const defaultTasks = [
+  {
+    id: "t1",
+    title: "Organizar brinquedos",
+    category: "Organização",
+    ownerId: "m3",
+    frequency: "Diária",
+    completed: true,
+  },
+  {
+    id: "t2",
+    title: "Preparar o jantar",
+    category: "Cozinha",
+    ownerId: "m2",
+    frequency: "Diária",
+    completed: false,
+  },
+  {
+    id: "t3",
+    title: "Limpar banheiro",
+    category: "Limpeza",
+    ownerId: "m1",
+    frequency: "Semanal",
+    completed: false,
+  },
+];
+
+const state = {
+  members: [...defaultMembers],
+  tasks: [...defaultTasks],
+  apiOnline: false,
+};
+
+const memberForm = document.getElementById("member-form");
+const taskForm = document.getElementById("task-form");
+const memberList = document.getElementById("member-list");
+const taskOwnerSelect = document.getElementById("task-owner");
+const taskList = document.getElementById("task-list");
+const statsGrid = document.getElementById("stats-grid");
+const categorySummary = document.getElementById("category-summary");
+const rankingList = document.getElementById("ranking-list");
+const apiStatus = document.getElementById("api-status");
+
+const createId = (prefix) => `${prefix}-${Math.random().toString(36).slice(2, 9)}`;
+
+const getSafeFieldValue = (formData, key) => {
+  const value = formData.get(key);
+  return typeof value === "string" ? value.trim() : "";
+};
+
+const createMetaChip = (label, value) => {
+  const chip = document.createElement("span");
+  chip.textContent = `${label}: ${value}`;
+  return chip;
+};
+
+const fetchJSON = async (path) => {
+  const response = await fetch(`${apiBase}${path}`);
+  if (!response.ok) {
+    throw new Error(`Falha em ${path}`);
+  }
+  return response.json();
+};
+
+const loadFromApi = async () => {
+  try {
+    const [members, tasks] = await Promise.all([
+      fetchJSON("/api/members"),
+      fetchJSON("/api/tasks"),
+    ]);
+
+    if (Array.isArray(members) && Array.isArray(tasks)) {
+      state.members = members;
+      state.tasks = tasks;
+      state.apiOnline = true;
+      apiStatus.textContent = "Status da API: conectada em /api/*";
+    }
+  } catch {
+    state.apiOnline = false;
+    apiStatus.textContent = "Status da API: offline (modo local de demonstração)";
+  }
+};
+
+const renderMembers = () => {
+  memberList.innerHTML = "";
+  taskOwnerSelect.innerHTML = "";
+
+  if (!state.members.length) {
+    const emptyOption = document.createElement("option");
+    emptyOption.value = "";
+    emptyOption.textContent = "Cadastre um familiar primeiro";
+    taskOwnerSelect.appendChild(emptyOption);
+    taskOwnerSelect.disabled = true;
+    return;
+  }
+
+  taskOwnerSelect.disabled = false;
+
+  state.members.forEach((member) => {
+    const pill = document.createElement("li");
+    pill.className = "pill";
+    pill.textContent = `${member.name} · ${member.role}`;
+    memberList.appendChild(pill);
+
+    const option = document.createElement("option");
+    option.value = member.id;
+    option.textContent = `${member.name} (${member.role})`;
+    taskOwnerSelect.appendChild(option);
+  });
+};
+
+const renderTasks = () => {
+  taskList.innerHTML = "";
+
+  if (!state.tasks.length) {
+    taskList.innerHTML = '<p class="muted">Nenhuma tarefa cadastrada.</p>';
+    return;
+  }
+
+  state.tasks.forEach((task) => {
+    const owner = state.members.find((member) => member.id === task.ownerId);
+    const card = document.createElement("article");
+    card.className = "task-card";
+
+    const title = document.createElement("strong");
+    title.textContent = task.title;
+
+    const meta = document.createElement("div");
+    meta.className = "task-meta";
+    meta.appendChild(createMetaChip("Categoria", task.category));
+    meta.appendChild(createMetaChip("Frequência", task.frequency));
+    meta.appendChild(createMetaChip("Responsável", owner?.name ?? "Não atribuído"));
+
+    card.appendChild(title);
+    card.appendChild(meta);
+
+    if (task.completed) {
+      const doneTag = document.createElement("span");
+      doneTag.className = "pill";
+      doneTag.textContent = "Concluída";
+      card.appendChild(doneTag);
+    } else {
+      const doneButton = document.createElement("button");
+      doneButton.type = "button";
+      doneButton.textContent = "Marcar como concluída";
+      doneButton.addEventListener("click", () => {
+        task.completed = true;
+        render();
+      });
+      card.appendChild(doneButton);
+    }
+
+    taskList.appendChild(card);
+  });
+};
+
+const renderStats = () => {
+  statsGrid.innerHTML = "";
+  categorySummary.innerHTML = "";
+
+  const totalTasks = state.tasks.length;
+  const completedTasks = state.tasks.filter((task) => task.completed).length;
+  const completionRate = totalTasks ? Math.round((completedTasks / totalTasks) * 100) : 0;
+
+  state.members.forEach((member) => {
+    const memberTasks = state.tasks.filter((task) => task.ownerId === member.id);
+    const memberCompleted = memberTasks.filter((task) => task.completed).length;
+    const memberRate = memberTasks.length
+      ? Math.round((memberCompleted / memberTasks.length) * 100)
+      : 0;
+
+    const card = document.createElement("div");
+    card.className = "stat-card";
+
+    const memberName = document.createElement("strong");
+    memberName.textContent = member.name;
+
+    const memberRole = document.createElement("span");
+    memberRole.className = "muted";
+    memberRole.textContent = member.role;
+
+    const value = document.createElement("span");
+    value.className = "stat-value";
+    value.textContent = `${memberCompleted}/${memberTasks.length}`;
+
+    const rateLabel = document.createElement("span");
+    rateLabel.className = "muted";
+    rateLabel.textContent = `Taxa de conclusão: ${memberRate}%`;
+
+    const progressBar = document.createElement("div");
+    progressBar.className = "progress-bar";
+
+    const progressFill = document.createElement("div");
+    progressFill.className = "progress-fill";
+    progressFill.style.width = `${memberRate}%`;
+
+    progressBar.appendChild(progressFill);
+    card.append(memberName, memberRole, value, rateLabel, progressBar);
+    statsGrid.appendChild(card);
+  });
+
+  const categoryMap = state.tasks.reduce((acc, task) => {
+    acc[task.category] = acc[task.category] ?? { total: 0, completed: 0 };
+    acc[task.category].total += 1;
+    if (task.completed) {
+      acc[task.category].completed += 1;
+    }
+    return acc;
+  }, {});
+
+  const totalRow = document.createElement("div");
+  totalRow.className = "category-row";
+  totalRow.innerHTML = `<strong>Total de tarefas</strong><strong>${completedTasks}/${totalTasks} (${completionRate}%)</strong>`;
+  categorySummary.appendChild(totalRow);
+
+  Object.entries(categoryMap).forEach(([category, data]) => {
+    const row = document.createElement("div");
+    row.className = "category-row";
+    const rate = data.total ? Math.round((data.completed / data.total) * 100) : 0;
+
+    const categoryName = document.createElement("span");
+    categoryName.textContent = category;
+
+    const categoryRate = document.createElement("span");
+    categoryRate.textContent = `${data.completed}/${data.total} (${rate}%)`;
+
+    row.append(categoryName, categoryRate);
+    categorySummary.appendChild(row);
+  });
+};
+
+const renderRanking = () => {
+  rankingList.innerHTML = "";
+
+  const ranking = state.members
+    .map((member) => {
+      const memberTasks = state.tasks.filter((task) => task.ownerId === member.id);
+      const completed = memberTasks.filter((task) => task.completed).length;
+      const rate = memberTasks.length ? Math.round((completed / memberTasks.length) * 100) : 0;
+      return { ...member, completed, total: memberTasks.length, rate };
+    })
+    .sort((a, b) => b.completed - a.completed || b.rate - a.rate);
+
+  ranking.forEach((member, index) => {
+    const item = document.createElement("li");
+    item.textContent = `${index + 1}º ${member.name} — ${member.completed}/${member.total} tarefas (${member.rate}%)`;
+    rankingList.appendChild(item);
+  });
+};
+
+const render = () => {
+  renderMembers();
+  renderTasks();
+  renderStats();
+  renderRanking();
+};
+
+memberForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const formData = new FormData(memberForm);
+  const name = getSafeFieldValue(formData, "memberName");
+  const role = getSafeFieldValue(formData, "memberRole") || "Outro";
+
+  if (!name) {
+    return;
+  }
+
+  state.members.push({
+    id: createId("member"),
+    name,
+    role,
+  });
+
+  memberForm.reset();
+  render();
+});
+
+taskForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+
+  if (!state.members.length) {
+    return;
+  }
+
+  const formData = new FormData(taskForm);
+  const title = getSafeFieldValue(formData, "taskTitle");
+
+  if (!title) {
+    return;
+  }
+
+  state.tasks.unshift({
+    id: createId("task"),
+    title,
+    category: getSafeFieldValue(formData, "taskCategory") || "Outros",
+    ownerId: getSafeFieldValue(formData, "taskOwner"),
+    frequency: getSafeFieldValue(formData, "taskFrequency") || "Diária",
+    completed: false,
+  });
+
+  taskForm.reset();
+  render();
+});
+
+(async () => {
+  await loadFromApi();
+  render();
+})();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>App Family - Controle de Tarefas</title>
+    <link rel="stylesheet" href="./styles.css" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+    />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="app-header">
+        <div>
+          <p class="eyebrow">App Family</p>
+          <h1>Controle de tarefas diárias da família</h1>
+          <p class="subtitle">
+            Organize atividades domésticas, acompanhe o progresso e visualize estatísticas por
+            familiar.
+          </p>
+          <p id="api-status" class="muted">Status da API: verificando...</p>
+        </div>
+        <button class="google-button" type="button">
+          <span class="google-dot"></span>
+          Entrar com Google
+        </button>
+      </header>
+
+      <main class="app-grid">
+        <section class="card">
+          <h2>Cadastro rápido da família</h2>
+          <p class="muted">
+            Adicione integrantes para começar a distribuir tarefas e acompanhar o desempenho.
+          </p>
+          <form id="member-form" class="stack">
+            <label class="field">
+              Nome do familiar
+              <input name="memberName" type="text" placeholder="Ex.: Maria" required />
+            </label>
+            <label class="field">
+              Perfil
+              <select name="memberRole">
+                <option value="Responsável">Responsável</option>
+                <option value="Filho(a)">Filho(a)</option>
+                <option value="Outro">Outro</option>
+              </select>
+            </label>
+            <button class="primary-button" type="submit">Adicionar familiar</button>
+          </form>
+          <ul id="member-list" class="pill-list"></ul>
+        </section>
+
+        <section class="card">
+          <h2>Nova tarefa doméstica</h2>
+          <p class="muted">Distribua atividades diárias, semanais ou recorrentes.</p>
+          <form id="task-form" class="stack">
+            <label class="field">
+              Tarefa
+              <input name="taskTitle" type="text" placeholder="Ex.: Lavar louça" required />
+            </label>
+            <label class="field">
+              Categoria
+              <select name="taskCategory">
+                <option value="Limpeza">Limpeza</option>
+                <option value="Organização">Organização</option>
+                <option value="Cozinha">Cozinha</option>
+                <option value="Compras">Compras</option>
+                <option value="Outros">Outros</option>
+              </select>
+            </label>
+            <label class="field">
+              Responsável
+              <select name="taskOwner" id="task-owner"></select>
+            </label>
+            <label class="field">
+              Frequência
+              <select name="taskFrequency">
+                <option value="Diária">Diária</option>
+                <option value="Semanal">Semanal</option>
+                <option value="Quinzenal">Quinzenal</option>
+                <option value="Mensal">Mensal</option>
+              </select>
+            </label>
+            <button class="primary-button" type="submit">Criar tarefa</button>
+          </form>
+        </section>
+
+        <section class="card">
+          <h2>Atividades em andamento</h2>
+          <p class="muted">Marque tarefas como concluídas para atualizar o dashboard.</p>
+          <div id="task-list" class="task-list"></div>
+        </section>
+
+        <section class="card">
+          <h2>Dashboard estatístico</h2>
+          <p class="muted">Resumo das tarefas concluídas por familiar e por categoria.</p>
+          <div class="stats-grid" id="stats-grid"></div>
+          <div class="category-summary" id="category-summary"></div>
+        </section>
+        <section class="card">
+          <h2>Ranking da família</h2>
+          <p class="muted">Membros mais ativos por tarefas concluídas.</p>
+          <ol id="ranking-list" class="ranking-list"></ol>
+        </section>
+
+      </main>
+
+      <section class="card highlight">
+        <h2>Como funciona a autenticação</h2>
+        <p>
+          Esta versão de demonstração mostra a entrada com Google como botão de autenticação. Na
+          implementação completa, o app usa o Google OAuth para criar contas seguras e sincronizar
+          o histórico das tarefas da família.
+        </p>
+      </section>
+    </div>
+
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,271 @@
+:root {
+  color-scheme: light;
+  --background: #f5f6fb;
+  --card: #ffffff;
+  --text: #1f2333;
+  --muted: #5e6477;
+  --primary: #4c6fff;
+  --primary-dark: #3956d6;
+  --accent: #f4b183;
+  --border: #e3e7f2;
+  --success: #2f9b58;
+  --warning: #f4c95d;
+  font-family: "Inter", system-ui, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--text);
+}
+
+.app-shell {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 20px 48px;
+}
+
+.app-header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  justify-content: space-between;
+  align-items: flex-start;
+  background: var(--card);
+  padding: 24px;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  box-shadow: 0 16px 30px rgba(26, 32, 44, 0.08);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 12px;
+  color: var(--muted);
+  margin: 0 0 8px;
+}
+
+h1 {
+  margin: 0 0 8px;
+  font-size: 28px;
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--muted);
+}
+
+.google-button {
+  border: none;
+  background: #111827;
+  color: #fff;
+  padding: 12px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  cursor: pointer;
+}
+
+.google-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: conic-gradient(#4285f4 0 25%, #db4437 0 50%, #f4b400 0 75%, #0f9d58 0);
+}
+
+.app-grid {
+  margin-top: 24px;
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 20px;
+  box-shadow: 0 10px 20px rgba(31, 35, 51, 0.06);
+}
+
+.highlight {
+  margin-top: 24px;
+  background: linear-gradient(135deg, #fef3e7, #ffffff);
+  border-color: #f9d5b5;
+}
+
+h2 {
+  margin-top: 0;
+  margin-bottom: 8px;
+  font-size: 20px;
+}
+
+.muted {
+  color: var(--muted);
+  margin-top: 0;
+}
+
+.stack {
+  display: grid;
+  gap: 12px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 14px;
+}
+
+input,
+select {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: #f8f9ff;
+  font-size: 14px;
+}
+
+.primary-button {
+  border: none;
+  background: var(--primary);
+  color: white;
+  border-radius: 12px;
+  padding: 10px 16px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.primary-button:hover {
+  background: var(--primary-dark);
+}
+
+.pill-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.pill {
+  background: #eef1ff;
+  color: var(--primary);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.task-list {
+  display: grid;
+  gap: 12px;
+}
+
+.task-card {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 14px;
+  display: grid;
+  gap: 6px;
+}
+
+.task-card button {
+  justify-self: flex-start;
+  border: none;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: #e6f8ee;
+  color: var(--success);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.task-meta {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.stats-grid {
+  display: grid;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.stat-card {
+  border-radius: 16px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  display: grid;
+  gap: 6px;
+}
+
+.stat-value {
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.progress-bar {
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: #eef1ff;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: var(--primary);
+}
+
+.category-summary {
+  margin-top: 16px;
+  display: grid;
+  gap: 10px;
+}
+
+.category-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+@media (min-width: 900px) {
+  .app-header {
+    flex-direction: row;
+    align-items: center;
+  }
+}
+
+.ranking-list {
+  margin: 14px 0 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 8px;
+}
+
+.ranking-list li {
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #fafbff;
+  font-size: 14px;
+}
+
+#api-status {
+  margin-top: 10px;
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal backend to expose family task data and computed statistics so the UI can show meaningful metrics and a ranking. 
- Allow the frontend to consume API data with a safe local fallback for demo/offline usage. 
- Surface API connectivity and a family ranking in the dashboard to improve visibility of activity.

### Description
- Add a small Go HTTP service with seeded data and endpoints `GET /api/health`, `GET /api/members`, `GET /api/tasks`, `GET /api/stats` and `GET /api/stats/ranking` implemented in `backend/internal/api/server.go` and an entrypoint in `backend/cmd/api/main.go`, plus `backend/go.mod`.
- Update the frontend (`frontend/index.html`, `frontend/app.js`, `frontend/styles.css`) to fetch `/api/members` and `/api/tasks`, show an API status indicator, render a new “Ranking da família” list and calculate stats with a local-data fallback when the API is unreachable.
- Add styling for the ranking list and API status and keep the UI interactive (create members/tasks, mark done) using the seeded or API-provided data.

### Testing
- Ran JavaScript syntax check with `node --check frontend/app.js` and it succeeded. 
- Ran `cd backend && go test ./...` which returned successfully (packages built; no test files). 
- Started the backend with `go run ./cmd/api` and served frontend with `python3 -m http.server 4173`, then validated API responses using `curl` against `/api/stats` and `/api/stats/ranking`, which returned the expected JSON. 
- Captured a Playwright screenshot of the running frontend to confirm UI updates (screenshot artifact generated) and all manual/automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69866d03593083218aa73d8b91e7e204)